### PR TITLE
merging of bool and int

### DIFF
--- a/src/Vivian.Lib/CodeAnalysis/Binding/Binder.cs
+++ b/src/Vivian.Lib/CodeAnalysis/Binding/Binder.cs
@@ -405,21 +405,21 @@ namespace Vivian.CodeAnalysis.Binding
 
         private BoundStatement BindIfStatement(IfStatementSyntax syntax)
         {
-            var condition = BindExpression(syntax.Condition, TypeSymbol.Bool);
+            var condition = BindExpression(syntax.Condition, TypeSymbol.Int);
             var thenStatement = BindStatement(syntax.ThenStatement);
             var elseStatement = syntax.ElseClause == null ? null : BindStatement(syntax.ElseClause.ElseStatement);
             return new BoundIfStatement(condition, thenStatement, elseStatement);
         }
         private BoundStatement BindWhileStatement(WhileStatementSyntax syntax)
         {
-            var condition = BindExpression(syntax.Condition, TypeSymbol.Bool);
+            var condition = BindExpression(syntax.Condition, TypeSymbol.Int);
             var body = BindLoopBody(syntax.Body, out var breakLabel, out var continueLabel); 
             return new BoundWhileStatement(condition, body, breakLabel, continueLabel);
         }
         private BoundStatement BindDoWhileStatement(DoWhileStatementSyntax syntax)
         {
             var body = BindLoopBody(syntax.Body, out var breakLabel, out var continueLabel);
-            var condition = BindExpression(syntax.Condition, TypeSymbol.Bool);
+            var condition = BindExpression(syntax.Condition, TypeSymbol.Int);
             return new BoundDoWhileStatement(body, condition, breakLabel, continueLabel);
         }
 
@@ -708,7 +708,6 @@ namespace Vivian.CodeAnalysis.Binding
                 case "object": 
                     return TypeSymbol.Object;
                 case "bool": 
-                    return TypeSymbol.Bool;
                 case "int": 
                     return TypeSymbol.Int;
                 case "string": 

--- a/src/Vivian.Lib/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Vivian.Lib/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -39,32 +39,31 @@ namespace Vivian.CodeAnalysis.Binding
             new BoundBinaryOperator(SyntaxKind.StarToken, BoundBinaryOperatorKind.Multiplication, TypeSymbol.Int),
             new BoundBinaryOperator(SyntaxKind.SlashToken, BoundBinaryOperatorKind.Division, TypeSymbol.Int),
             new BoundBinaryOperator(SyntaxKind.ModuloToken, BoundBinaryOperatorKind.Modulo, TypeSymbol.Int),
-            
+
             new BoundBinaryOperator(SyntaxKind.AmpersandToken, BoundBinaryOperatorKind.BitwiseAnd, TypeSymbol.Int),
             new BoundBinaryOperator(SyntaxKind.PipeToken, BoundBinaryOperatorKind.BitwiseOr, TypeSymbol.Int),
             new BoundBinaryOperator(SyntaxKind.HatToken, BoundBinaryOperatorKind.BitwiseXor, TypeSymbol.Int),
-            
-            new BoundBinaryOperator(SyntaxKind.EqualsEqualsToken, BoundBinaryOperatorKind.Equals, TypeSymbol.Int, TypeSymbol.Bool),
-            new BoundBinaryOperator(SyntaxKind.EqualsEqualsToken, BoundBinaryOperatorKind.Equals, TypeSymbol.String, TypeSymbol.Bool),
 
-            new BoundBinaryOperator(SyntaxKind.BangEqualsToken, BoundBinaryOperatorKind.NotEquals, TypeSymbol.Int, TypeSymbol.Bool),
-            new BoundBinaryOperator(SyntaxKind.BangEqualsToken, BoundBinaryOperatorKind.NotEquals, TypeSymbol.String, TypeSymbol.Bool),
+            new BoundBinaryOperator(SyntaxKind.EqualsEqualsToken, BoundBinaryOperatorKind.Equals, TypeSymbol.Int),
+            new BoundBinaryOperator(SyntaxKind.EqualsEqualsToken, BoundBinaryOperatorKind.Equals, TypeSymbol.String, TypeSymbol.Int),
 
-            new BoundBinaryOperator(SyntaxKind.LessToken, BoundBinaryOperatorKind.Less, TypeSymbol.Int, TypeSymbol.Bool),
-            new BoundBinaryOperator(SyntaxKind.LessOrEqualsToken, BoundBinaryOperatorKind.LessOrEquals, TypeSymbol.Int, TypeSymbol.Bool),
-            new BoundBinaryOperator(SyntaxKind.GreaterToken, BoundBinaryOperatorKind.Greater, TypeSymbol.Int, TypeSymbol.Bool),
-            new BoundBinaryOperator(SyntaxKind.GreaterOrEqualsToken, BoundBinaryOperatorKind.GreaterOrEquals, TypeSymbol.Int, TypeSymbol.Bool),
+            new BoundBinaryOperator(SyntaxKind.BangEqualsToken, BoundBinaryOperatorKind.NotEquals, TypeSymbol.Int, TypeSymbol.Int),
+            new BoundBinaryOperator(SyntaxKind.BangEqualsToken, BoundBinaryOperatorKind.NotEquals, TypeSymbol.String, TypeSymbol.Int),
 
-            new BoundBinaryOperator(SyntaxKind.AmpersandToken, BoundBinaryOperatorKind.BitwiseAnd, TypeSymbol.Bool),
-            new BoundBinaryOperator(SyntaxKind.PipeToken, BoundBinaryOperatorKind.BitwiseOr, TypeSymbol.Bool),
-            new BoundBinaryOperator(SyntaxKind.HatToken, BoundBinaryOperatorKind.BitwiseXor, TypeSymbol.Bool),
-            new BoundBinaryOperator(SyntaxKind.AmpersandAmpersandToken, BoundBinaryOperatorKind.LogicalAnd, TypeSymbol.Bool),
-            new BoundBinaryOperator(SyntaxKind.PipePipeToken, BoundBinaryOperatorKind.LogicalOr, TypeSymbol.Bool),
-            new BoundBinaryOperator(SyntaxKind.EqualsEqualsToken, BoundBinaryOperatorKind.Equals, TypeSymbol.Bool),
-            new BoundBinaryOperator(SyntaxKind.BangEqualsToken, BoundBinaryOperatorKind.NotEquals, TypeSymbol.Bool),
-            
+            new BoundBinaryOperator(SyntaxKind.LessToken, BoundBinaryOperatorKind.Less, TypeSymbol.Int, TypeSymbol.Int),
+            new BoundBinaryOperator(SyntaxKind.LessOrEqualsToken, BoundBinaryOperatorKind.LessOrEquals, TypeSymbol.Int, TypeSymbol.Int),
+            new BoundBinaryOperator(SyntaxKind.GreaterToken, BoundBinaryOperatorKind.Greater, TypeSymbol.Int, TypeSymbol.Int),
+            new BoundBinaryOperator(SyntaxKind.GreaterOrEqualsToken, BoundBinaryOperatorKind.GreaterOrEquals, TypeSymbol.Int, TypeSymbol.Int),
+
+            new BoundBinaryOperator(SyntaxKind.AmpersandToken, BoundBinaryOperatorKind.BitwiseAnd, TypeSymbol.Int),
+            new BoundBinaryOperator(SyntaxKind.PipeToken, BoundBinaryOperatorKind.BitwiseOr, TypeSymbol.Int),
+            new BoundBinaryOperator(SyntaxKind.HatToken, BoundBinaryOperatorKind.BitwiseXor, TypeSymbol.Int),
+            new BoundBinaryOperator(SyntaxKind.AmpersandAmpersandToken, BoundBinaryOperatorKind.LogicalAnd, TypeSymbol.Int),
+            new BoundBinaryOperator(SyntaxKind.PipePipeToken, BoundBinaryOperatorKind.LogicalOr, TypeSymbol.Int),
+            new BoundBinaryOperator(SyntaxKind.EqualsEqualsToken, BoundBinaryOperatorKind.Equals, TypeSymbol.Int),
+            new BoundBinaryOperator(SyntaxKind.BangEqualsToken, BoundBinaryOperatorKind.NotEquals, TypeSymbol.Int),
+
             new BoundBinaryOperator(SyntaxKind.PlusToken, BoundBinaryOperatorKind.Addition, TypeSymbol.String),
-            
         };
 
         public static BoundBinaryOperator Bind(SyntaxKind syntaxKind, TypeSymbol leftType, TypeSymbol rightType)

--- a/src/Vivian.Lib/CodeAnalysis/Binding/BoundLiteralExpression.cs
+++ b/src/Vivian.Lib/CodeAnalysis/Binding/BoundLiteralExpression.cs
@@ -10,9 +10,6 @@ namespace Vivian.CodeAnalysis.Binding
             Value = value;
             switch (value)
             {
-                case bool:
-                    Type = TypeSymbol.Bool;
-                    break;
                 case int:
                     Type = TypeSymbol.Int;
                     break;

--- a/src/Vivian.Lib/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Vivian.Lib/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -136,12 +136,8 @@ namespace Vivian.CodeAnalysis.Binding
         private static void WriteLiteralExpression(BoundLiteralExpression node, IndentedTextWriter writer)
         {
             var value = node.Value.ToString();
-            if (node.Type == TypeSymbol.Bool)
-            {
-                writer.WriteKeyword(value);
-            }
             
-            else if (node.Type == TypeSymbol.Int)
+            if (node.Type == TypeSymbol.Int)
             {
                 writer.WriteNumber(value);
             }

--- a/src/Vivian.Lib/CodeAnalysis/Binding/BoundUnaryOperator.cs
+++ b/src/Vivian.Lib/CodeAnalysis/Binding/BoundUnaryOperator.cs
@@ -24,7 +24,7 @@ namespace Vivian.CodeAnalysis.Binding
 
         private static BoundUnaryOperator[] _operators =
         {
-            new BoundUnaryOperator(SyntaxKind.BangToken, BoundUnaryOperatorKind.LogicalNegation, TypeSymbol.Bool),
+            new BoundUnaryOperator(SyntaxKind.BangToken, BoundUnaryOperatorKind.LogicalNegation, TypeSymbol.Int),
             
             new BoundUnaryOperator(SyntaxKind.PlusToken, BoundUnaryOperatorKind.Identity, TypeSymbol.Int),
             new BoundUnaryOperator(SyntaxKind.MinusToken, BoundUnaryOperatorKind.Negation, TypeSymbol.Int),

--- a/src/Vivian.Lib/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Vivian.Lib/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -243,7 +243,7 @@ namespace Vivian.CodeAnalysis.Binding
                     return new BoundLiteralExpression(!value);
                 }
 
-                var unaryOperator = BoundUnaryOperator.Bind(SyntaxKind.BangToken, TypeSymbol.Bool);
+                var unaryOperator = BoundUnaryOperator.Bind(SyntaxKind.BangToken, TypeSymbol.Int);
                 return new BoundUnaryExpression(unaryOperator, condition);
             }
           

--- a/src/Vivian.Lib/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Vivian.Lib/CodeAnalysis/Binding/Conversion.cs
@@ -36,15 +36,15 @@ namespace Vivian.CodeAnalysis.Binding
                 return Conversion.Explicit;
             }
             
-            if (from == TypeSymbol.Bool || from == TypeSymbol.Int)
+            if (from == TypeSymbol.Int)
             {
                 if (to == TypeSymbol.String)
                     return Conversion.Explicit;
             }
-            
+
             if (from == TypeSymbol.String)
             {
-                if (to == TypeSymbol.Bool || to == TypeSymbol.Int)
+                if (to == TypeSymbol.Int)
                     return Conversion.Explicit;
             }
 

--- a/src/Vivian.Lib/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Vivian.Lib/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -4,7 +4,6 @@
     {
         public static readonly TypeSymbol Error = new TypeSymbol("?");
         public static readonly TypeSymbol Object = new TypeSymbol("object");
-        public static readonly TypeSymbol Bool = new TypeSymbol("bool");
         public static readonly TypeSymbol Int = new TypeSymbol("int");
         public static readonly TypeSymbol String = new TypeSymbol("string");
         public static readonly TypeSymbol Void = new TypeSymbol("void");

--- a/src/Vivian.Lib/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Vivian.Lib/CodeAnalysis/Syntax/Parser.cs
@@ -455,8 +455,8 @@ namespace Vivian.CodeAnalysis.Syntax
 
         private ExpressionSyntax ParseBooleanLiteral()
         {
-            var isTrue = Current.Kind == SyntaxKind.TrueKeyword;
-            var keywordToken = isTrue ? MatchToken(SyntaxKind.TrueKeyword) : MatchToken(SyntaxKind.FalseKeyword);
+            var isTrue = Current.Kind == SyntaxKind.TrueKeyword ? 1 : 0;
+            var keywordToken = Current.Kind == SyntaxKind.TrueKeyword ? MatchToken(SyntaxKind.TrueKeyword) : MatchToken(SyntaxKind.FalseKeyword);
             
             return new LiteralExpressionSyntax(_syntaxTree, keywordToken, isTrue);
         }


### PR DESCRIPTION
bool is no longer used internally
keywords `true` and `false` still exist and are mapped to `1` and `0` respectively

all boolean operations are now done on ints and return either `1` or `0`

`bool("true")` evaluates to `1` and
`bool("false")` evaluates to `0`
int casting has the same result